### PR TITLE
Radio with square brackets

### DIFF
--- a/src/service/ValidationService.js
+++ b/src/service/ValidationService.js
@@ -59,7 +59,7 @@
             var result = false;
 
             if (this.type.toLowerCase() === "radio" && this.name.replace(/\s/g, "") !== "") {
-                var elements = DOMUtils.getElementsByAttribute(document.body, "input", "name", this.name);
+                var elements = DOMUtils.getElementsByAttribute(document.body, "input", "name", this.name.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&"));
 
                 var i = 0;
                 while (i < elements.length && !result) {

--- a/src/test/regula-tests.js
+++ b/src/test/regula-tests.js
@@ -10293,6 +10293,26 @@ test('Test @Checked against checked radio-button group (passing, markup)', funct
     deleteElements();
 });
 
+test('Test @Checked against checked radio-button group using square brackets in name', function() {
+    var $radio0 = createInputElement("radio0", "@Checked", "radio");
+    $radio0.attr("name", "Awesome[Radios]");
+
+    var $radio1 = createInputElement("radio1", null, "radio");
+    $radio1.attr("name", "Awesome[Radios]");
+
+    var $radio2 = createInputElement("radio2", null, "radio");
+    $radio2.attr("name", "Awesome[Radios]");
+    $radio2.attr("checked", "true");
+
+    var $radio3 = createInputElement("radio3", null, "radio");
+    $radio3.attr("name", "Awesome[Radios]");
+
+    regula.bind();
+    equal(regula.validate().length, 0, "The @Checked constraint must not fail against a checked radio-button group");
+
+    deleteElements();
+});
+
 test('Test @Checked against checked radio-button group (passing, programmatic)', function() {
     var $radio0 = createInputElement("radio0", null, "radio");
     $radio0.attr("name", "AwesomeRadios");


### PR DESCRIPTION
When radio elements contain square brackets in their name, the failingElements array is empty.

It happens because the name is passed to `DOMUtils.getElementsByAttribute` which takes a regular exception. I escaped the regexp symbol by using the solution suggested here: http://stackoverflow.com/a/6969486/188760
